### PR TITLE
Include petId in error message instead of null value

### DIFF
--- a/src/main/java/org/springframework/samples/petclinic/web/api/VisitResource.java
+++ b/src/main/java/org/springframework/samples/petclinic/web/api/VisitResource.java
@@ -54,11 +54,11 @@ public class VisitResource extends AbstractResourceController {
 
 		final Pet pet = clinicService.findPetById(petId);
 		if (pet == null) {
-			throw new BadRequestException("Pet with Id '" + pet + "' is unknown.");
+			throw new BadRequestException("Pet with Id '" + petId + "' is unknown.");
 		}
-		
+
 		pet.addVisit(visit);
-		
+
 		clinicService.saveVisit(visit);
 	}
 }


### PR DESCRIPTION
Fixes an error where a null value (pet) is added to the error message instead of the petId.